### PR TITLE
fix: Update license format to use SPDX string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Python SDK for Kafka event streaming (Grasp Labs)"
 readme = "README.md"
 requires-python = ">=3.11"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 authors = [
     {name = "Grasp Labs", email = "hello@grasplabs.no"},
 ]


### PR DESCRIPTION
## 🔧 Fix License Format

This PR fixes the deprecated license format in `pyproject.toml` to use the modern SPDX string format.

### Changes
- Change from deprecated `{text = "Apache-2.0"}` format to simple `"Apache-2.0"` string
- Resolves setuptools deprecation warnings during package build
- Follows modern packaging standards for license specification

### Why This Change
The current license format triggers deprecation warnings:
```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
```

### Testing
- ✅ Package builds without deprecation warnings
- ✅ License information is preserved
- ✅ Follows current packaging standards

**This will trigger the first PyPI release (v0.1.1) when merged!** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author