### PR TITLE
fix: Remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["kafka", "event-streaming", "sdk", "python", "grasp-labs"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## 🔧 Remove Deprecated License Classifier

This PR removes the deprecated license classifier to eliminate build warnings.

### Changes
- Remove `License :: OSI Approved :: Apache Software License` classifier
- Resolves setuptools deprecation warnings about license classifiers
- License is now properly specified using SPDX format in `license` field

### Why This Change
The current license classifier triggers deprecation warnings:
```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
```

### Testing
- ✅ Package builds without license classifier warnings
- ✅ License information is preserved in SPDX format
- ✅ Follows current packaging standards

**This will test the fixed PyPI deployment workflow!** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author